### PR TITLE
立ち上げられるコンテナの数に制限を設ける

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -21,9 +21,9 @@ exit_code=0
 # echo "Username: $3"
 # echo "Fingerprint: $4"
 
-mkdir -p /tmp/build/$1 || true
-cat | tar -x -C /tmp/build/$1
-cd /tmp/build/$1
+mkdir -p /tmp/build/$3/$PROJECT_NAME || true
+cat | tar -x -C /tmp/build/$3/$PROJECT_NAME
+cd /tmp/build/$3/$PROJECT_NAME
 
 if [[ -f docker-compose.yml ]]; then
   echo "=====> docker-compose.yml was detected"
@@ -59,6 +59,6 @@ else
 fi
 
 cd $BASE_DIR
-rm -rf /tmp/build/$1
+rm -rf /tmp/build/$3/$PROJECT_NAME
 
 exit $exit_code

--- a/files/receiver
+++ b/files/receiver
@@ -23,6 +23,21 @@ exit_code=0
 
 mkdir -p /tmp/build/$3/$PROJECT_NAME || true
 cat | tar -x -C /tmp/build/$3/$PROJECT_NAME
+
+# NOTE:
+# 各userそれぞれ最新3件のみコンテナが立ち上がっている状態にする
+cd /tmp/build/$3
+
+PROJECT_COUNT=$(ls -1 | wc -l)
+if [[ $PROJECT_COUNT -gt 3 ]]; then
+  OLD_PROJECT=$(ls -rt | head -n 1)
+  cd /tmp/build/$3/$OLD_PROJECT
+  docker-compose -p $OLD_PROJECT stop > /dev/null
+  docker-compose -p $OLD_PROJECT rm > /dev/null
+  cd $BASE_DIR
+  rm -rf /tmp/build/$3/$OLD_PROJECT
+fi
+
 cd /tmp/build/$3/$PROJECT_NAME
 
 if [[ -f docker-compose.yml ]]; then
@@ -57,8 +72,5 @@ else
   echo "=====> docker-compose.yml was NOT found!"
   exit_code=1
 fi
-
-cd $BASE_DIR
-rm -rf /tmp/build/$3/$PROJECT_NAME
 
 exit $exit_code


### PR DESCRIPTION
## WHY

現状ではpushした分だけコンテナが立ち上がるので、リソース不足に陥ってしまう。
各ユーザ最新3件のみコンテナが立ち上がっている状態にする。
## WHAT
- pushされたリポジトリのパスを変更した
- 3件以上コンテナが立ち上がっている場合は、一番古いリポジトリから生成されたコンテナを消すようにした
