### PR TITLE
イメージをレジストリから使うようにする

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -49,10 +49,10 @@ if [[ -f docker-compose.yml ]]; then
   echo "=====> docker-compose.yml was detected"
 
   echo "=====> Building Dockerfile..."
-  docker build -t $IMAGE_TAG build .
+  docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG build .
 
   echo "=====> Pushing image..."
-  docker push localhost:5000/$IMAGE_TAG
+  docker -H tcp://$HOST_IP:2375 push localhost:5000/$IMAGE_TAG
 
   echo "=====> Building..."
   sed -i -e "s/build:.*/image: localhost:5000\/$USER_NAME\/$REPOSITORY/g" docker-compose.yml

--- a/files/receiver
+++ b/files/receiver
@@ -40,10 +40,20 @@ fi
 
 cd /tmp/build/$3/$PROJECT_NAME
 
+# username/projectname
+IMAGE_TAG=$USER_NAME/$1
+
 if [[ -f docker-compose.yml ]]; then
   echo "=====> docker-compose.yml was detected"
 
+  echo "=====> Building Dockerfile..."
+  docker build -t $IMAGE_TAG build .
+
+  echo "=====> Pushing image..."
+  docker push localhost:5000/$IMAGE_TAG
+
   echo "=====> Building..."
+  sed -i -e "s/build:.*/image: localhost:5000\/$USER_NAME\/$1/g" docker-compose.yml
   docker-compose -p $PROJECT_NAME build
 
   echo "=====> Pulling..."

--- a/files/receiver
+++ b/files/receiver
@@ -9,8 +9,10 @@ export DOCKER_HOST=tcp://$HOST_IP:2377
 export ETCDCTL_ENDPOINT=http://$HOST_IP:2379
 
 # dtan4-paus-edc8df8
+REPOSITORY=$(echo "$1")
+REVISION=$(echo "$2")
 USER_NAME=$(echo "$3")
-PROJECT_NAME=$USER_NAME-$(echo "$1")-$(echo $2 | awk '{ print substr($0, 0, 8) }')
+PROJECT_NAME=$USER_NAME-$REPOSITORY-$(echo $REVISION | awk '{ print substr($0, 0, 8) }')
 
 BASE_DOMAIN=`cat /base-domain`
 
@@ -21,27 +23,27 @@ exit_code=0
 # echo "Username: $3"
 # echo "Fingerprint: $4"
 
-mkdir -p /tmp/build/$3/$PROJECT_NAME || true
-cat | tar -x -C /tmp/build/$3/$PROJECT_NAME
+mkdir -p /tmp/build/$USER_NAME/$PROJECT_NAME || true
+cat | tar -x -C /tmp/build/$USER_NAME/$PROJECT_NAME
 
 # NOTE:
 # 各userそれぞれ最新3件のみコンテナが立ち上がっている状態にする
-cd /tmp/build/$3
+cd /tmp/build/$USER_NAME
 
 PROJECT_COUNT=$(ls -1 | wc -l)
 if [[ $PROJECT_COUNT -gt 3 ]]; then
   OLD_PROJECT=$(ls -rt | head -n 1)
-  cd /tmp/build/$3/$OLD_PROJECT
+  cd /tmp/build/$USER_NAME/$OLD_PROJECT
   docker-compose -p $OLD_PROJECT stop > /dev/null
   docker-compose -p $OLD_PROJECT rm > /dev/null
   cd $BASE_DIR
-  rm -rf /tmp/build/$3/$OLD_PROJECT
+  rm -rf /tmp/build/$USER_NAME/$OLD_PROJECT
 fi
 
-cd /tmp/build/$3/$PROJECT_NAME
+cd /tmp/build/$USER_NAME/$PROJECT_NAME
 
 # username/projectname
-IMAGE_TAG=$USER_NAME/$1
+IMAGE_TAG=$USER_NAME/$REPOSITORY
 
 if [[ -f docker-compose.yml ]]; then
   echo "=====> docker-compose.yml was detected"
@@ -53,7 +55,7 @@ if [[ -f docker-compose.yml ]]; then
   docker push localhost:5000/$IMAGE_TAG
 
   echo "=====> Building..."
-  sed -i -e "s/build:.*/image: localhost:5000\/$USER_NAME\/$1/g" docker-compose.yml
+  sed -i -e "s/build:.*/image: localhost:5000\/$USER_NAME\/$REPOSITORY/g" docker-compose.yml
   docker-compose -p $PROJECT_NAME build
 
   echo "=====> Pulling..."
@@ -71,13 +73,13 @@ if [[ -f docker-compose.yml ]]; then
   domain=$(etcdctl set /vulcand/frontends/$PROJECT_NAME/frontend "{\"Type\": \"http\", \"BackendId\": \"$PROJECT_NAME\", \"Route\": \"Host(\`$PROJECT_NAME.$BASE_DOMAIN\`) && PathRegexp(\`/\`)\"}" \
               | jq -r .Route | sed -E "s/Host\(\`(.+?)\`\).+/\1/")
 
-  echo "=====> $1 was deployed at http://$domain/"
+  echo "=====> $REPOSITORY was deployed at http://$domain/"
 
   # username.wantedlyapp.com
   domain=$(etcdctl set /vulcand/frontends/$USER_NAME/frontend "{\"Type\": \"http\", \"BackendId\": \"$PROJECT_NAME\", \"Route\": \"Host(\`$USER_NAME.$BASE_DOMAIN\`) && PathRegexp(\`/\`)\"}" \
               | jq -r .Route | sed -E "s/Host\(\`(.+?)\`\).+/\1/")
 
-  echo "=====> $1 was deployed at http://$domain/"
+  echo "=====> $REPOSITORY was deployed at http://$domain/"
 else
   echo "=====> docker-compose.yml was NOT found!"
   exit_code=1


### PR DESCRIPTION
## WHY

現状docker-swarmでdocker-composeを使う場合、

```
# docker-compose.yml
web:
  build: . # <==
```

この記載が使えない。
(swarm-agent自身がイメージを引っ張ってくる必要があるため)

そのため、
1. gitreceiverでDockerfileをビルド
2. registryにイメージをプッシュ
3. registryにあるイメージを使って docker-compose build を叩く

この流れで処理を行う必要がある。
## WHAT
- イメージのビルドとプッシュを行うようにした
- docker-compose.ymlを書き換え、レジストリにあるイメージを使用するようにした
