### PR TITLE
Fix syntax error

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -49,7 +49,7 @@ if [[ -f docker-compose.yml ]]; then
   echo "=====> docker-compose.yml was detected"
 
   echo "=====> Building Dockerfile..."
-  docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG build .
+  docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG .
 
   echo "=====> Pushing image..."
   docker -H tcp://$HOST_IP:2375 push localhost:5000/$IMAGE_TAG


### PR DESCRIPTION
# WHY, WHAT

引数がおかしなことになっていたので修正。

```
$ git push paus 
Warning: Permanently added the ECDSA host key for IP address '54.92.36.200' to the list of known hosts.
Counting objects: 310, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (223/223), done.
Writing objects: 100% (310/310), 42.88 KiB | 0 bytes/s, done.
Total 310 (delta 126), reused 195 (delta 69)
=====> docker-compose.yml was detected
=====> Building Dockerfile...
remote: docker: "build" requires 1 argument.
remote: See 'docker build --help'.
remote: 
remote: Usage:  docker build [OPTIONS] PATH | URL | -
remote: 
remote: Build an image from a Dockerfile
To git@git.wantedlyapp.com:delay_message_on_rails
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'git@git.wantedlyapp.com:delay_message_on_rails'
```
