### PR TITLE
レジストリにプッシュするためのタグを追加

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -74,13 +74,13 @@ if [[ -f docker-compose.yml ]]; then
   domain=$(etcdctl set /vulcand/frontends/$PROJECT_NAME/frontend "{\"Type\": \"http\", \"BackendId\": \"$PROJECT_NAME\", \"Route\": \"Host(\`$PROJECT_NAME.$BASE_DOMAIN\`) && PathRegexp(\`/\`)\"}" \
               | jq -r .Route | sed -E "s/Host\(\`(.+?)\`\).+/\1/")
 
-  echo "=====> $REPOSITORY was deployed at http://$domain/"
+  echo "=====> $REPOSITORY was deployed at https://$domain/"
 
   # username.wantedlyapp.com
   domain=$(etcdctl set /vulcand/frontends/$USER_NAME/frontend "{\"Type\": \"http\", \"BackendId\": \"$PROJECT_NAME\", \"Route\": \"Host(\`$USER_NAME.$BASE_DOMAIN\`) && PathRegexp(\`/\`)\"}" \
               | jq -r .Route | sed -E "s/Host\(\`(.+?)\`\).+/\1/")
 
-  echo "=====> $REPOSITORY was deployed at http://$domain/"
+  echo "=====> $REPOSITORY was deployed at https://$domain/"
 else
   echo "=====> docker-compose.yml was NOT found!"
   exit_code=1

--- a/files/receiver
+++ b/files/receiver
@@ -50,6 +50,7 @@ if [[ -f docker-compose.yml ]]; then
 
   echo "=====> Building Dockerfile..."
   docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG .
+  docker -H tcp://$HOST_IP:2375 tag -f $IMAGE_TAG localhost:5000/$IMAGE_TAG
 
   echo "=====> Pushing image..."
   docker -H tcp://$HOST_IP:2375 push localhost:5000/$IMAGE_TAG


### PR DESCRIPTION
## WHY

イメージにタグがついていないことにより、ビルドしたイメージがレジストリにプッシュできない状態になっていた。
## WHAT

```
localhost:5000/username/repository
```

のようなタグをイメージにつけるようにした。
