### PR TITLE
Remove old url

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -38,6 +38,9 @@ if [[ $PROJECT_COUNT -gt 3 ]]; then
   docker-compose -p $OLD_PROJECT rm -f > /dev/null || true
   cd $BASE_DIR
   rm -rf /repos/$USER_NAME/$OLD_PROJECT
+
+  etcdctl rm /vulcand/backends/$OLD_PROJECT --recursive || true
+  etcdctl rm /vulcand/frontends/$OLD_PROJECT --recursive || true
 fi
 
 cd /repos/$USER_NAME/$PROJECT_NAME

--- a/files/receiver
+++ b/files/receiver
@@ -33,14 +33,15 @@ cd /repos/$USER_NAME
 PROJECT_COUNT=$(ls -1 | wc -l)
 if [[ $PROJECT_COUNT -gt 3 ]]; then
   OLD_PROJECT=$(ls -rt | head -n 1)
+
+  etcdctl rm /vulcand/backends/$OLD_PROJECT --recursive || true
+  etcdctl rm /vulcand/frontends/$OLD_PROJECT --recursive || true
+
   cd /repos/$USER_NAME/$OLD_PROJECT
   docker-compose -p $OLD_PROJECT stop > /dev/null || true
   docker-compose -p $OLD_PROJECT rm -f > /dev/null || true
   cd $BASE_DIR
   rm -rf /repos/$USER_NAME/$OLD_PROJECT
-
-  etcdctl rm /vulcand/backends/$OLD_PROJECT --recursive || true
-  etcdctl rm /vulcand/frontends/$OLD_PROJECT --recursive || true
 fi
 
 cd /repos/$USER_NAME/$PROJECT_NAME


### PR DESCRIPTION
## WHY

コンテナは削除されているがetcdにデータが残ってしまっており、過去のURLが生きている状態になっていた。(コンテナは削除されているため真っ白な画面が表示される)
## WHAT

コンテナの削除と同時にetcdから対象のデータを削除するようにした。
