### PR TITLE
Change to better build replace logic

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -52,6 +52,29 @@ IMAGE_TAG=$USER_NAME/$REPOSITORY
 if [[ -f docker-compose.yml ]]; then
   echo "=====> docker-compose.yml was detected"
 
+  printf '' > new-docker-compose.yml
+
+  IMG_ID=0
+  cat docker-compose.yml | while IFS='' read -r line
+  do
+    build_dir=$(expr "$line" : ' *build: *\(.*\)')
+    if [ ${#build_dir} != 0 ]; then
+      (( IMG_ID++ ))
+      echo "=====> Building Dockerfile..."
+      docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG$IMG_ID $build_dir
+      docker -H tcp://$HOST_IP:2375 tag -f $IMAGE_TAG$IMG_ID localhost:5000/$IMAGE_TAG$IMG_ID
+
+      echo "=====> Pushing image..."
+      docker -H tcp://$HOST_IP:2375 push localhost:5000/$IMAGE_TAG$IMG_ID
+
+      printf "%s\n" "$line" | sed -e "s/build:.*/image: localhost:5000\/$IMAGE_TAG$IMG_ID/g" >> new-docker-compose.yml
+    else
+      printf "%s\n" "$line" >> new-docker-compose.yml
+    fi
+  done
+
+  mv -f new-docker-compose.yml docker-compose.yml
+
   echo "=====> Building Dockerfile..."
   docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG .
   docker -H tcp://$HOST_IP:2375 tag -f $IMAGE_TAG localhost:5000/$IMAGE_TAG
@@ -60,7 +83,6 @@ if [[ -f docker-compose.yml ]]; then
   docker -H tcp://$HOST_IP:2375 push localhost:5000/$IMAGE_TAG
 
   echo "=====> Building..."
-  sed -i -e "s/build:.*/image: localhost:5000\/$USER_NAME\/$REPOSITORY/g" docker-compose.yml
   docker-compose -p $PROJECT_NAME build
 
   echo "=====> Pulling..."

--- a/files/receiver
+++ b/files/receiver
@@ -75,13 +75,6 @@ if [[ -f docker-compose.yml ]]; then
 
   mv -f new-docker-compose.yml docker-compose.yml
 
-  echo "=====> Building Dockerfile..."
-  docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG .
-  docker -H tcp://$HOST_IP:2375 tag -f $IMAGE_TAG localhost:5000/$IMAGE_TAG
-
-  echo "=====> Pushing image..."
-  docker -H tcp://$HOST_IP:2375 push localhost:5000/$IMAGE_TAG
-
   echo "=====> Building..."
   docker-compose -p $PROJECT_NAME build
 


### PR DESCRIPTION
## WHY

https://github.com/wantedly/infrastructure/issues/857

現状の、sedで置き換える方法だと、build場所の指定を無視する他、2個のDockerイメージを結びつける方法など諸々できなくなっていて、Herokuと比べた時のPausの良さが全てなくなってしまっていた。
## WHAT

直した。

特に難しかったところは、1行ずつ読み込むところで、先頭の空白を消さない部分。以下を参考にした。
http://stackoverflow.com/questions/1648055/preserving-leading-white-space-while-readingwriting-a-file-line-by-line-in-bas

cc @munisystem 
