### PR TITLE
unset is 0

### DIFF
--- a/files/receiver
+++ b/files/receiver
@@ -65,7 +65,7 @@ IFS=$'\n'
 for line in `cat docker-compose.yml`
 do
   build_dir=$(echo $line | awk '/build:/ { print $2 }')
-  if [ ${build_dir} != 0 ]; then
+  if [ ${#build_dir} != 0 ]; then
     IMG_ID=$(( $IMG_ID + 1 ))
     printf "=====> Building Dockerfile..."
     docker -H tcp://$HOST_IP:2375 build -t $IMAGE_TAG$IMG_ID $build_dir


### PR DESCRIPTION
## WHY

`remote: /home/git/receiver: line 68: [: !=: unary operator expected`

と表示されるのがダサい
## WHAT
- 0か1 で判定が行えるようにした
